### PR TITLE
Fix for torch 2.0 updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,8 +61,6 @@ def load_pipeline(model_name, pipeline_name, controlnet, pipe):
         else:
             pipe.to(device)
 
-        pipe.enable_xformers_memory_efficient_attention()
-
         return pipe, f"Successfully loaded Pipeline: {pipeline_name} with {model_name}"
 
     except Exception as e:

--- a/app.py
+++ b/app.py
@@ -11,17 +11,15 @@ from utils import (
     get_audio_key_frame_information,
     get_video_frame_information,
     load_video_frames,
+    set_xformers,
     to_pil_image,
 )
 
 DEBUG = os.getenv("DEBUG_MODE", "false").lower() == "true"
 OUTPUT_BASE_PATH = os.getenv("OUTPUT_BASE_PATH", "./generated")
-prompt_generator = gr.Interface.load("spaces/doevent/prompt-generator")
+USE_XFORMERS = set_xformers()
 
-if int(torch.__version__.split(".")[0]) == 2:
-    USE_XFORMERS = True
-else:
-    USE_XFORMERS = False
+prompt_generator = gr.Interface.load("spaces/doevent/prompt-generator")
 
 
 def load_pipeline(model_name, pipeline_name, controlnet, pipe):

--- a/app.py
+++ b/app.py
@@ -18,6 +18,11 @@ DEBUG = os.getenv("DEBUG_MODE", "false").lower() == "true"
 OUTPUT_BASE_PATH = os.getenv("OUTPUT_BASE_PATH", "./generated")
 prompt_generator = gr.Interface.load("spaces/doevent/prompt-generator")
 
+if int(torch.__version__.split(".")[0]) == 2:
+    USE_XFORMERS = True
+else:
+    USE_XFORMERS = False
+
 
 def load_pipeline(model_name, pipeline_name, controlnet, pipe):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -60,6 +65,9 @@ def load_pipeline(model_name, pipeline_name, controlnet, pipe):
             pipe.enable_model_cpu_offload()
         else:
             pipe.to(device)
+
+        if USE_XFORMERS:
+            pipe.enable_xformers_memory_efficient_attention()
 
         return pipe, f"Successfully loaded Pipeline: {pipeline_name} with {model_name}"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ ftfy
 gradio
 comet_ml
 imageio-ffmpeg
-xformers
 pandas
 keyframed
 kornia

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pandas
 keyframed
 kornia
 triton
+xformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ pandas
 keyframed
 kornia
 triton
-xformers
+torch
+torchvision

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
-import re
 import json
+import re
+
 import librosa
 import numpy as np
 import torch
@@ -207,3 +208,10 @@ def save_video(frames, filename="./output.mp4", fps=24, quality=95, audio_input=
 def save_parameters(save_path, parameters):
     with open(f"{save_path}/parameters.json", "w") as f:
         json.dump(parameters, f)
+
+
+def set_xformers():
+    if int(torch.__version__.split(".")[0]) == 2:
+        return True
+
+    return False

--- a/utils.py
+++ b/utils.py
@@ -211,7 +211,15 @@ def save_parameters(save_path, parameters):
 
 
 def set_xformers():
-    if int(torch.__version__.split(".")[0]) == 2:
+    torch_is_version_2 = int(torch.__version__.split(".")[0]) == 2
+    try:
+        import xformers
+
+        xformers_available = True
+    except (ImportError, ModuleNotFoundError):
+        xformers_available = False
+
+    if (not torch_is_version_2) and xformers_available:
         return True
 
     return False


### PR DESCRIPTION
This PR:
Removes xformers as a dependency and adds an additional check to determine whether a pipeline should use `enable_xformers_memory_efficient_attention` method.  

The latest version of Colab uses Torch 2.0 and CUDA-11.8 by default. This is causing issues with xformers. Since xformers is no longer necessary with Torch 2.0, the dependency has been removed. An additional check for xformers has been added in case users are using older versions of Pytorch.     